### PR TITLE
Docs/ata reuniao 09 abril 2025

### DIFF
--- a/docs/atas/ata02.md
+++ b/docs/atas/ata02.md
@@ -8,7 +8,7 @@ Reunião realizada online via **Microsoft Teams**.
 |          | Data       | Início| Término |
 |----------|------------|-------|---------|
 | Previsto | 09/04/2025 | 20:00 | 21:00   |
-| Realizado| 09/04/2025 | 20:00 | 21:50   |
+| Realizado| 09/04/2025 | 20:00 | 20:50   |
 
 ## Participantes presentes:
 - [x] [Ana Victória Guedes da Costa](https://github.com/navicg)

--- a/docs/atas/ata02.md
+++ b/docs/atas/ata02.md
@@ -1,0 +1,46 @@
+# Ata da 2ª Reunião de Requisitos de Software – Grupo 08
+
+### Local
+Reunião realizada online via **Microsoft Teams**.
+
+### Horário da Reunião
+
+|          | Data       | Início| Término |
+|----------|------------|-------|---------|
+| Previsto | 09/04/2025 | 20:00 | 21:00   |
+| Realizado| 09/04/2025 | 20:00 | 21:50   |
+
+## Participantes presentes:
+- [x] [Ana Victória Guedes da Costa](https://github.com/navicg)
+- [x] [Artur Mendonça Arruda](https://github.com/ArtyMend07)
+- [x] [Gabriel Lopes](https://github.com/BrzGab)
+- [x] [João Marcos Moraes de Andrade](https://github.com/JJOAOMARCOSS)
+- [x] [Karoline Luz da Conceição](https://github.com/KarolineLuz)
+- [x] [Lucas Mendonça Arruda](https://github.com/lucasarruda9)
+- [x] [Luiza da Silva Pugas](https://github.com/Luizaxx)
+
+## Pauta:
+* Discutir a concordância geral com o cronograma prévio do projeto e definir ajustes necessários.
+*  Debater a necessidade de refazer partes dos artefatos que não estejam de acordo com os critérios de qualidade de software.
+* Estabelecer a padronização dos commits, mediante o uso de pull requests, issues e a criação de branches específicas.
+* Discutir a mudança da metodologia de gestão de trabalho, passando de Kanban para Scrum, e apresentar uma breve explicação de como funcionarão as sprints.
+
+
+
+## Decisões:
+* Ficou acordada a mudança da metodologia de trabalho de Kanban para Scrum.
+* O cronograma prévio será mantido com ajustes a serem definidos conforme o andamento do projeto.
+* A equipe adotará a padronização dos commits utilizando pull requests, issues e branches para uma organização mais eficiente.
+* Partes dos artefatos que não atenderem aos critérios de qualidade serão refeitas.
+* Ficou decidido que, até a próxima reunião, o termo de uso do aplicativo será uma das prioridades máximas do projeto, e que deverá ser documentado até essa data.
+
+## Link da gravação
+[Link da primeira reunião](https://youtu.be/CwQa5EshHGc)
+## Próxima Reunião 11/04/2025 às 20h
+
+## Histórico de versão
+Versão  | Data | Descrição | Autor(es) | Revisor(es)
+-------- | ------ | ------ | ---------- | ----------
+1.0 | 09/04/2025 | Ata da 2ª Reunião  | [Artur Mendonça Arruda](https://github.com/ArtyMend07) | [Lucas Mendonça Arruda](https://github.com/lucasarruda9)
+
+


### PR DESCRIPTION
# :rocket: Criação da ata da 2ª reunião de requisitos – 09/04/2025

## :clipboard: Descrição
Esta Pull Request adiciona a ata da 2ª reunião de requisitos do Grupo 08, realizada em 09 de abril de 2025 via Microsoft Teams. O documento detalha os participantes presentes, os tópicos discutidos, decisões tomadas, o link da gravação e o histórico de versão da ata.

## :wrench: Tarefas Realizadas
- [x] Criação do arquivo da ata
- [x] Registro dos participantes presentes
- [x] Documentação da pauta e decisões da reunião
- [x] Inclusão do link da gravação

## :pushpin: Problema Relacionado
Fixes #2    

## :mag: Mudanças Realizadas
- Adição da ata da 2ª reunião do grupo (09/04/2025) em formato Markdown
- Estruturação da ata conforme o padrão definido: local, horário, participantes, pauta, decisões, link de gravação e histórico de versão
- Registro da versão 1.0 com autoria e revisão identificadas

## :busts_in_silhouette: Revisores
- [Luiza da Silva Pugas](https://github.com/Luizaxx)
