### PR TITLE
Docs/ata terceira reuniao

### DIFF
--- a/docs/atas/ata03.md
+++ b/docs/atas/ata03.md
@@ -1,0 +1,46 @@
+# Ata da 3ª Reunião de Requisitos de Software – Grupo 08
+
+### Local
+Reunião realizada online via **Microsoft Teams**.
+
+### Horário da Reunião
+|          | Data       | Início| Término |
+|----------|------------|-------|---------|
+| Previsto | 11/04/2025 | 21:00 | 21:30   |
+| Realizado| 11/04/2025 | 21:00 | 21:40   |
+
+## Participantes presentes:
+- [x] [Ana Victória Guedes da Costa](https://github.com/navicg)
+- [x] [Artur Mendonça Arruda](https://github.com/ArtyMend07)
+- [x] [Gabriel Lopes](https://github.com/BrzGab)
+- [x] [João Marcos Moraes de Andrade](https://github.com/JJOAOMARCOSS)
+- [x] [Karoline Luz da Conceição](https://github.com/KarolineLuz)
+- [x] [Lucas Mendonça Arruda](https://github.com/lucasarruda9)
+- [x] [Luiza da Silva Pugas](https://github.com/Luizaxx)
+
+## Pauta:
+* Verificar o andamento das tarefas determinadas no cronograma para a entrega 1 e atualizações gerais do projeto.
+* Discutir a adoção do MkDocs como ferramenta de documentação do projeto.
+* Planejar a apresentação da entrega 1, incluindo detalhes sobre a gravação.
+* Definir responsáveis pela criação e gerenciamento das sprints.
+* Estabelecer padrões de referenciação dos artefatos produzidos.
+* Revisar o cronograma do projeto e identificar pontos que necessitam de atualização.
+* Verificaro andamento da documentação do termo de uso do app.
+
+## Decisões:
+* A equipe adotará o MkDocs como ferramenta oficial de documentação do projeto.
+* Foi definido o planejamento da apresentação da entrega 1, incluindo detalhes sobre como será realizada a gravação.
+* Foram designados responsáveis para a criação e gerenciamento das sprints.
+* Foi estabelecido um padrão para referenciação dos artefatos produzidos.
+* O cronograma foi revisado e foram identificados pontos que necessitam de atualização.
+
+## Link da gravação
+[Link da terceira reunião](https://www.youtube.com/watch?v=QyOagQC9pRs)
+
+## Próxima Reunião
+12/04/2025 às 15h
+
+## Histórico de versão
+| Versão | Data | Descrição | Autor(es) | Revisor(es) |
+|--------|------|-----------|-----------|-------------|
+| 1.0 | 11/04/2025 | Ata da 3ª Reunião | [Gabriel Lopes de Amorim](https://github.com/BrzGab) | [Artur Mendonça Arruda](https://github.com/ArtyMend07) |

--- a/docs/atas/ata03.md
+++ b/docs/atas/ata03.md
@@ -19,17 +19,17 @@ Reunião realizada online via **Microsoft Teams**.
 - [x] [Luiza da Silva Pugas](https://github.com/Luizaxx)
 
 ## Pauta:
-* Verificar o andamento das tarefas determinadas no cronograma para a entrega 1 e atualizações gerais do projeto.
+* Verificar o andamento das tarefas determinadas no cronograma para o ponto de controle 1 e atualizações gerais do projeto.
 * Discutir a adoção do MkDocs como ferramenta de documentação do projeto.
-* Planejar a apresentação da entrega 1, incluindo detalhes sobre a gravação.
+* Planejar a apresentação do ponto de controle 1, incluindo detalhes sobre a gravação.
 * Definir responsáveis pela criação e gerenciamento das sprints.
 * Estabelecer padrões de referenciação dos artefatos produzidos.
 * Revisar o cronograma do projeto e identificar pontos que necessitam de atualização.
-* Verificaro andamento da documentação do termo de uso do app.
+* Verificar o andamento da documentação do termo de uso do app.
 
 ## Decisões:
 * A equipe adotará o MkDocs como ferramenta oficial de documentação do projeto.
-* Foi definido o planejamento da apresentação da entrega 1, incluindo detalhes sobre como será realizada a gravação.
+* Foi definido o planejamento da apresentação do ponto de controle 1, incluindo detalhes sobre como será realizada a gravação.
 * Foram designados responsáveis para a criação e gerenciamento das sprints.
 * Foi estabelecido um padrão para referenciação dos artefatos produzidos.
 * O cronograma foi revisado e foram identificados pontos que necessitam de atualização.


### PR DESCRIPTION
# :rocket: Adição da Ata da 3ª Reunião - Grupo 08

## :clipboard: Descrição
Esta PR adiciona a ata da 3ª reunião de requisitos do Grupo 08, realizada em 11/04/2025 via Microsoft Teams. O documento registra os participantes, pautas discutidas, decisões tomadas e encaminhamentos para as próximas etapas do projeto.

## :wrench: Tarefas Realizadas
- [x] Criação da ata da 3ª reunião
- [x] Documentação das pautas discutidas
- [x] Registro das decisões tomadas
- [x] Formatação do documento em markdown
- [x] Revisão do conteúdo

## :mag: Mudanças Realizadas
Foi adicionado o arquivo markdown contendo a ata completa da 3ª reunião do grupo, incluindo informações sobre:
- Adoção do MkDocs como ferramenta de documentação
- Planejamento da apresentação da entrega 1
- Definição de responsáveis para as sprints
- Estabelecimento de padrões para referenciação de artefatos
- Revisão do cronograma e identificação de pontos a serem atualizados

## :camera: Capturas de Tela (Opcional)
N/A

## :bulb: Observações Adicionais
A ata inclui o link para a gravação da reunião e informações sobre a próxima reunião agendada para 12/04/2025.

## :busts_in_silhouette: Revisores
- [Artur Mendonça Arruda] (@ArtyMend07)

## :gear: Alterações Técnicas (Opcional)
N/A