### PR TITLE
Correção dos Caminhos das Imagens Quebradas

### DIFF
--- a/docs/planejamento/heatmap.md
+++ b/docs/planejamento/heatmap.md
@@ -13,7 +13,7 @@ Este documento descreve a ferramenta utilizada para gerar o heatmap de disponibi
 <div align="center">
 <p>Figura 1: Heatmap gerado com base nas disponibilidades semanais dos integrantes do grupo.</p>
 
-<img src="../assets/planejamento/Heatmap_Grupo8_Req.png" alt="Grade Horária Grupo08" width="750px">
+<img src="https://uploaddeimagens.com.br/images/004/891/632/original/heatmap.jpeg?1744559790" alt="Grade Horária Grupo08" width="750px">
 
 <p><em>Fonte: Elaborado pelo autor (João Marcos Moraes de Andrade, 2025).</em></p>
 </div>


### PR DESCRIPTION
# :rocket: Correção dos Caminhos das Imagens Quebradas

## :clipboard: Descrição
Esta Pull Request corrige os caminhos das imagens que estavam quebrados nas páginas do MkDocs, impedindo que elas fossem exibidas corretamente no site. Agora, todas as imagens (como o Rich Picture e o Heatmap) estão com os links diretos e funcionais, garantindo que sejam renderizadas corretamente na visualização final.

## :wrench: Tarefas Realizadas
- [x] Corrigido o link da imagem do Rich Picture.
- [x] Corrigido o link da imagem do Heatmap da Grade Horária.

## :pushpin: Problema Relacionado
Fixes #37

## :mag: Mudanças Realizadas
- Atualização dos caminhos das imagens hospedadas externamente para garantir compatibilidade com o MkDocs.
- As imagens agora utilizam a tag `<img>` com atributos corretos (`alt`, `width`, etc) e estão envolvidas por uma `div` centralizada com legenda e fonte.

## :bulb: Observações Adicionais
- Verifique se todas as páginas com imagens estão renderizando corretamente após o merge.
- Manter o padrão adotado para futuras imagens adicionadas no projeto.

## :busts_in_silhouette: Revisores
- [Luiza da Silva Pugas](@Luizaxx)