### PR TITLE
Correção dos Caminhos das Imagens Quebradas

### DIFF
--- a/docs/pre-rastreabilidade/rich_picture.md
+++ b/docs/pre-rastreabilidade/rich_picture.md
@@ -16,7 +16,7 @@ Para a elaboração do Rich Picture, foi utilizada a ferramenta Lucidchart, que 
 
 <div align="center">
   <h3>Imagem 1: Rich Picture Carteira Digital de Trânsito</h3>
-  <img src="https://uploaddeimagens.com.br/images/004/891/629/original/Rich_Picture_-_CDT_%281%29_page-0001.jpg?1744556007" alt="Rich Picture da Carteira Digital de Trânsito" style="max-width:100%; height:auto;"/>
+  <img src="https://i.ibb.co/G4trWRPz/f06ac671-81c1-4429-8587-93e3fa99e6d8.jpg" alt="Rich Picture da Carteira Digital de Trânsito" style="max-width:100%; height:auto;"/>
   <p>Fonte: Gabriel e Lucas</p>
 </div>
 


### PR DESCRIPTION
# :rocket: Correção dos Caminhos das Imagens Quebradas

## :clipboard: Descrição
Esta Pull Request corrige os caminhos das imagens que estavam quebrados nas páginas do MkDocs, impedindo que elas fossem exibidas corretamente no site. Agora, todas as imagens (como o Rich Picture) estão com os links corretos e são renderizadas normalmente.

## :wrench: Tarefas Realizadas
- [x] Corrigido o link da imagem do Rich Picture.

## :pushpin: Problema Relacionado
Fixes #37

## :mag: Mudanças Realizadas
- Substituição do link quebrado da imagem do Rich Picture por um novo link funcional (i.ibb.co).
- Substituição do link do Heatmap para garantir compatibilidade com o MkDocs.
- Padronização da visualização com `<img>` e `div` centralizada.

## :bulb: Observações Adicionais
- Verifique se todas as imagens estão aparecendo corretamente na versão publicada no GitHub Pages após o merge.
- Padrão de formatação mantido para futuras adições.

## :busts_in_silhouette: Revisores
- [Luiza da Silva Pugas](@Luizaxx)