### PR TITLE
Ajuste na fonte do rich picture

### DIFF
--- a/docs/pre-rastreabilidade/rich_picture.md
+++ b/docs/pre-rastreabilidade/rich_picture.md
@@ -17,7 +17,7 @@ Para a elaboração do Rich Picture, foi utilizada a ferramenta Lucidchart, que 
 <div align="center">
   <h3>Imagem 1: Rich Picture Carteira Digital de Trânsito</h3>
   <img src="https://i.ibb.co/G4trWRPz/f06ac671-81c1-4429-8587-93e3fa99e6d8.jpg" alt="Rich Picture da Carteira Digital de Trânsito" style="max-width:100%; height:auto;"/>
-  <p>Fonte: Gabriel e Lucas</p>
+  <p>Figura 1: Primeira versão do Rich Picture(Fonte: Elaborado pelos autores: Gabriel e Lucas, 2025)</p>
 </div>
 
 ## Referências

--- a/docs/pre-rastreabilidade/rich_picture.md
+++ b/docs/pre-rastreabilidade/rich_picture.md
@@ -15,7 +15,6 @@ Para a elaboração do Rich Picture, foi utilizada a ferramenta Lucidchart, que 
 ## Rich Picture - Carteira Digital de Trânsito
 
 <div align="center">
-  <h3>Imagem 1: Rich Picture Carteira Digital de Trânsito</h3>
   <img src="https://i.ibb.co/G4trWRPz/f06ac671-81c1-4429-8587-93e3fa99e6d8.jpg" alt="Rich Picture da Carteira Digital de Trânsito" style="max-width:100%; height:auto;"/>
   <p>Figura 1: Primeira versão do Rich Picture(Fonte: Elaborado pelos autores: Gabriel e Lucas, 2025)</p>
 </div>


### PR DESCRIPTION
# :rocket: Ajuste na citação de fonte da figura

## :clipboard: Descrição
Esta PR corrige a formatação da fonte da figura, modificando para "Fonte: Elaborado pelos autores: Gabriel e Lucas, 2025."

## :wrench: Tarefas Realizadas
- [x] Ajuste na formatação da citação da fonte da figura
- [x] Padronização conforme requisitos do documento

## :mag: Mudanças Realizadas
Foi alterada a formatação da citação da fonte de uma figura no documento markdown, substituindo o formato anterior por "Fonte: Elaborado pelos autores: Gabriel e Lucas, 2025." conforme os padrões de citação exigidos.

## :bulb: Observações Adicionais
Esta é uma alteração pequena mas necessária para manter a consistência nas citações do documento.

## :busts_in_silhouette: Revisores
- [Artur] (@ArtyMend07 )