### PR TITLE
:memo:Adição da ata  25/04/2025

### DIFF
--- a/docs/atas/ata06.md
+++ b/docs/atas/ata06.md
@@ -1,0 +1,52 @@
+# Ata da 6ª Reunião de Requisitos de Software – Grupo 08
+
+### Local
+Reunião realizada online via **Microsoft Teams**.
+
+### Horário da Reunião
+|          | Data       | Início| Término |
+|----------|------------|-------|---------|
+| Previsto | 25/04/2025 | 20:00 | 21:00   |
+| Realizado| 25/04/2025 | 20:18 | 20:36  |
+
+## Participantes presentes:
+- [x] [Ana Victória Guedes da Costa](https://github.com/navicg)
+- [x] [Artur Mendonça Arruda](https://github.com/ArtyMend07)
+- [x] [Gabriel Lopes](https://github.com/BrzGab)
+- [x] [João Marcos Moraes de Andrade](https://github.com/JJOAOMARCOSS)
+- [x] [Karoline Luz da Conceição](https://github.com/KarolineLuz)
+- [x] [Lucas Mendonça Arruda](https://github.com/lucasarruda9)
+- [x] [Luiza da Silva Pugas](https://github.com/Luizaxx)
+
+## Pauta:
+
+- Alteração do aplicativo analisado, de "Carteira Digital de Trânsito" para "e-GDF".
+- Redefinição dos artefatos de requisitos devido à troca do app.
+- Organização do repositório e atualização da página via GitHub Pages.
+- Definição de responsáveis pelas tarefas.
+
+
+## Decisões
+
+- Substituir o app “Carteira Digital de Trânsito” por “e-GDF” e manter o sprint atual apenas para organização inicial.  
+- Priorizar a entrega da elicitação de requisitos antes de gerar os artefatos (Termo de Uso, Rich Picture, App Selecionado, Lista de Apps e README).  
+- Utilizar técnicas de elicitação: introspecção, análise de documentos, entrevista, prototipação e questionário.  
+- João Marcos e Luiza da Silva Pugas ficarão responsáveis pelo README do projeto e pela configuração do GitHub Pages (incluindo automação via MkDocs).  
+- Gabriel Lopes de Amorim ficará com o Rich Picture; o responsável pelo Termo de Uso será definido em seguida; Ana Victória cuidará do App Selecionado e da Lista de Apps.  
+- Próximos passos: concluir a entrega da elicitação, atualizar o repositório e produzir/revisar os artefatos finais.  
+
+
+## Bibliografia:
+
+UNIVERSIDADE DE BRASÍLIA. FGA0313 – Requisitos de Software – Turma T03 (2025.1 – 35M12). Docente: ANDRE BARROS DE SALES. Plano de ensino disponível em: [Plano de Ensino](https://aprender3.unb.br/pluginfile.php/3095981/mod_resource/content/60/FGA0303-T03v2.pdf). Acesso em: 25 abr. 2025.
+
+## Link da gravação
+[Link da sexta reunião](https://youtu.be/5b8SrFMpjB8)
+
+## Próxima Reunião
+02/05/2025 às 20h
+
+## Histórico de versão
+| Versão | Data | Descrição | Autor(es) | Revisor(es) |
+|--------|------|-----------|-----------|-------------|
+| 1.0 | 25/04/2025 | Ata da 6ª Reunião | [Karoline Luz da Conceição](https://github.com/KarolineLuz)| [Ana Victória Guedes da Costa](https://github.com/navicg) | 

--- a/docs/atas/ata06.md
+++ b/docs/atas/ata06.md
@@ -41,7 +41,7 @@ Reunião realizada online via **Microsoft Teams**.
 UNIVERSIDADE DE BRASÍLIA. FGA0313 – Requisitos de Software – Turma T03 (2025.1 – 35M12). Docente: ANDRE BARROS DE SALES. Plano de ensino disponível em: [Plano de Ensino](https://aprender3.unb.br/pluginfile.php/3095981/mod_resource/content/60/FGA0303-T03v2.pdf). Acesso em: 25 abr. 2025.
 
 ## Link da gravação
-[Link da sexta reunião](https://youtu.be/5b8SrFMpjB8)
+[Link da sexta reunião](https://www.youtube.com/watch?v=axWCWykGDcs&feature=youtu.be)
 
 ## Próxima Reunião
 02/05/2025 às 20h


### PR DESCRIPTION
# :rocket: Ata referente à 6ª Reunião do Grupo 08 de Requisitos de Software

## :clipboard: Descrição
Esta Pull Request adiciona a ata da sexta reunião do grupo 08 da disciplina de Requisitos de Software, realizada em 25 de abril de 2025 via Microsoft Teams. Nela, foi discutida a mudança de aplicativo analisado para o e-GDF, o foco nas técnicas de elicitação para a próxima entrega e a reorganização das tarefas entre os membros do grupo.

## :wrench: Tarefas Realizadas
- [x] Redigir a ata com base nas falas da reunião.
- [x] Formalizar a pauta e decisões tomadas.
- [x] Atualizar o histórico de versão do documento.

## :pushpin: Problema Relacionado
Closes #64

## :mag: Mudanças Realizadas
* Inclusão da ata da 6ª reunião em formato Markdown.
* Registro das responsabilidades de cada integrante após a mudança de aplicativo.
* Definição do foco da próxima entrega em elicitação.
* Adição do link da gravação da reunião.

## :bulb: Observações Adicionais
A ata foi baseada integralmente na transcrição da gravação da reunião, priorizando a clareza e fidelidade às decisões do grupo. Não foram incluídos participantes que não se manifestaram.

## :busts_in_silhouette: Revisores
- [Ana Victória Guedes da Costa](https://github.com/navicg)
