### PR TITLE
docs: Adiciona caminho do ROI e 100$

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,8 @@ nav:
     - Priorização:
       - First Things First: elicitacao/tec_priorizacao/first_things_first.md
       - Moscow: elicitacao/tec_priorizacao/moscow.md
+      - ROI: elicitacao/tec_priorizacao/roi.md
+      - 100: elicitacao/tec_priorizacao/100.md
     - Requisitos Elicitados: elicitacao/req_elicitados.md
     - Perfil de Usuário: elicitacao/perfil_de_usuario.md
   - Verificação:


### PR DESCRIPTION
# :rocket: Adição dos caminhos ROI e First Things First no mkdocs.yml

## :clipboard: Descrição
Adição dos caminhos dos documentos ROI e First Things First na seção de Elicitação > Priorização do arquivo mkdocs.yml.

## :wrench: Tarefas Realizadas
- [ ] Adicionar caminho do ROI no mkdocs.yml
- [ ] Adicionar caminho do First Things First no mkdocs.yml
- [ ] Verificar se a estrutura de navegação está correta

## :pushpin: Problema Relacionado
Closes #99 

## :mag: Mudanças Realizadas
Adicionados os seguintes caminhos na seção de Elicitação > Priorização:
- ROI: elicitacao/tec_priorizacao/roi.md
- First Things First: elicitacao/tec_priorizacao/first_things_first.md

## :busts_in_silhouette: Revisores
- [@BrzGab ]